### PR TITLE
Added kramdown=0 attribute til mermaid div tag

### DIFF
--- a/lib/jekyll-mermaid.rb
+++ b/lib/jekyll-mermaid.rb
@@ -8,7 +8,7 @@ module Jekyll
     def render(context)
       @config = context.registers[:site].config['mermaid']
       "<script src=\"#{@config['src']}\"></script>"\
-      "<div class=\"mermaid\">#{super}</div>"
+      "<div class=\"mermaid\" kramdown=\"0\">#{super}</div>"
     end
   end
 end


### PR DESCRIPTION
It turns out that when using Kramdown in Jekyll all > and < (greater than/lesser than) are transformed into entities &amp;gt; regardless of what I configure for entity_output in _config.yaml.

By adding 

```
<div class="mermaid" kramdown="0">
```

to the output, the problem disappears.

What do you think?
