### PR TITLE
Preserve spaces and breaklines

### DIFF
--- a/lib/jekyll-mermaid.rb
+++ b/lib/jekyll-mermaid.rb
@@ -8,7 +8,7 @@ module Jekyll
     def render(context)
       @config = context.registers[:site].config['mermaid']
       "<script src=\"#{@config['src']}\"></script>"\
-      "<div class=\"mermaid\">#{super}</div>"
+      "<pre><div class=\"mermaid\">#{super}</div></pre>"
     end
   end
 end


### PR DESCRIPTION
Some layouts compress the code of the pages. As the content of this div must be preserved as is, it is better to protect it :)