### PR TITLE
Explicitly mark the mermaid div to not be processed as markdown

### DIFF
--- a/lib/jekyll-mermaid.rb
+++ b/lib/jekyll-mermaid.rb
@@ -8,7 +8,7 @@ module Jekyll
     def render(context)
       @config = context.registers[:site].config['mermaid']
       "<script src=\"#{@config['src']}\"></script>"\
-      "<div class=\"mermaid\">#{super}</div>"
+      "<div class=\"mermaid\" markdown=\"0\">#{super}</div>"
     end
   end
 end


### PR DESCRIPTION
Kramdown can be configured to do markdown parsing also
inside HTML tags. In that mode, you need to use the
attribute markdown="0" to protect the contents of html from processing.

Without this attribute, the processor would at the very least add
a `<p>` tag around the div content.